### PR TITLE
計算したsha1ハッシュをメモリ上に保存

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.*
 
 plugins {
-    kotlin("jvm") version "1.4.10"
+    kotlin("jvm") version "1.5.10"
     id("com.github.johnrengelman.shadow") version "6.0.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("com.github.kittinunf.fuel:fuel:2.2.3")
     implementation("me.rayzr522:jsonmessage:1.2.1")
     implementation("commons-codec:commons-codec:1.15")
+    implementation("org.mariadb.jdbc:mariadb-java-client:2.6.0")
 }
 
 tasks {
@@ -36,6 +37,7 @@ tasks {
         relocate("com.github.kittinunf.result", UUID.randomUUID().toString())
         relocate("me.rayzr522.jsonmessage", UUID.randomUUID().toString())
         relocate("org.apache.commons.codec", UUID.randomUUID().toString())
+        relocate("org.mariadb.jdbc", UUID.randomUUID().toString())
 
         minimize()
     }

--- a/src/main/kotlin/net/azisaba/yukitexture/YukiTexture.kt
+++ b/src/main/kotlin/net/azisaba/yukitexture/YukiTexture.kt
@@ -72,10 +72,13 @@ class YukiTexture : JavaPlugin() {
                 .tooltip(buildString {
                     append("${CC.YELLOW}URL: ${CC.RESET}${response.url}")
                     append("\n")
-                    @Suppress("SimplifiableCallChain")
-                    append(response.headers
-                        .map { "${CC.AQUA}${it.key}: ${CC.RESET}${it.value.joinToString(" ")}" }
-                        .joinToString("\n"))
+                    append(
+                        response.headers
+                            .entries
+                            .joinToString("\n") {
+                                "${CC.AQUA}${it.key}: ${CC.RESET}${it.value.joinToString(" ")}"
+                            }
+                    )
                 })
                 .then(" です。")
                 .send(player)

--- a/src/main/kotlin/net/azisaba/yukitexture/YukiTexture.kt
+++ b/src/main/kotlin/net/azisaba/yukitexture/YukiTexture.kt
@@ -86,17 +86,15 @@ class YukiTexture : JavaPlugin() {
             sha1 = DigestUtils.sha1Hex(result.get())
         }
         JSONMessage.create()
-            .then("$prefix ")
-            .then("SHA-1")
-            .tooltip(sha1)
-            .then(" を計算しました。")
-            .send(player)
-        JSONMessage.create()
             .title(0, 100, 20, player)
         JSONMessage.create("プレイヤーのリソースパックを変更中...")
             .subtitle(player)
         player.setResourcePack(tex, sha1)
-        player.sendMessage("$prefix ${CC.GREEN}完了しました。")
+        JSONMessage.create()
+            .then("$prefix ")
+            .then("${CC.GREEN}完了しました。")
+            .tooltip("SHA-1: $sha1")
+            .send(player)
     }
 
     fun applyTexAsync(player: Player) {

--- a/src/main/kotlin/net/azisaba/yukitexture/command/TextureCommand.kt
+++ b/src/main/kotlin/net/azisaba/yukitexture/command/TextureCommand.kt
@@ -9,7 +9,9 @@ import org.bukkit.entity.Player
 class TextureCommand(private val plugin: YukiTexture) : CommandExecutor {
 
     override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<String>): Boolean {
-        if (sender is Player) plugin.applyTexAsync(sender)
+        if (sender is Player) {
+            plugin.server.scheduler.runTaskAsynchronously(plugin) { plugin.applyTex(sender) }
+        }
         return true
     }
 }

--- a/src/main/kotlin/net/azisaba/yukitexture/listener/TextureListener.kt
+++ b/src/main/kotlin/net/azisaba/yukitexture/listener/TextureListener.kt
@@ -4,11 +4,70 @@ import net.azisaba.yukitexture.YukiTexture
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
 
 class TextureListener(private val plugin: YukiTexture) : Listener {
 
     @EventHandler
     fun onJoin(e: PlayerJoinEvent) {
-        if (e.player.hasPermission("yukitexture.receive")) plugin.applyTexAsync(e.player)
+        if (e.player.hasPermission("yukitexture.receive") && plugin.tex.isNotBlank()) {
+            plugin.server.scheduler.runTaskLaterAsynchronously(plugin, {
+                plugin.db.let {
+                    if (it == null) {
+                        plugin.applyTex(e.player)
+                        return@let
+                    }
+                    val player = it.findOne(
+                        "SELECT `last_server` FROM `${plugin.dbPrefix}players` WHERE `uuid` = ?",
+                        e.player.uniqueId.toString(),
+                        //plugin.serverName,
+                    )
+                    if (
+                        player == null
+                        || player["last_server"] == null
+                        || !plugin.getTextureConfig().getStringList("dontApplyTexture").contains(player["last_server"])
+                    ) {
+                        plugin.applyTex(e.player)
+                    }
+                }
+            }, 1)
+        }
+        plugin.db?.let {
+            plugin.server.scheduler.runTaskLaterAsynchronously(plugin, {
+                it.execute(
+                    "INSERT INTO `${plugin.dbPrefix}players` (`uuid`, `last_server`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `last_server` = ?, `pending_quit` = 0",
+                    e.player.uniqueId.toString(),
+                    plugin.serverName,
+                    plugin.serverName,
+                )
+            }, plugin.getTextureConfig().getLong("delay", 5))
+        }
+    }
+
+    @EventHandler
+    fun onQuit(e: PlayerQuitEvent) {
+        plugin.db?.let {
+            plugin.server.scheduler.runTaskAsynchronously(plugin) {
+                it.execute(
+                    "INSERT INTO `${plugin.dbPrefix}players` (`uuid`, `last_server`, `pending_quit`) VALUES (?, ?, 1) ON DUPLICATE KEY UPDATE `last_server` = ?, `pending_quit` = 1",
+                    e.player.uniqueId.toString(),
+                    plugin.serverName,
+                    plugin.serverName,
+                )
+            }
+            plugin.server.scheduler.runTaskLaterAsynchronously(plugin, {
+                val player = it.findOne(
+                    "SELECT `uuid` FROM `${plugin.dbPrefix}players` WHERE `uuid` = ? AND `last_server` = ? AND `pending_quit` = 1",
+                    e.player.uniqueId.toString(),
+                    plugin.serverName,
+                )
+                if (player != null) {
+                    it.execute(
+                        "UPDATE `${plugin.dbPrefix}players` SET `last_server` = NULL, `pending_quit` = 0 WHERE `uuid` = ?",
+                        e.player.uniqueId.toString(),
+                    )
+                }
+            }, 10) // around 1s
+        }
     }
 }

--- a/src/main/kotlin/net/azisaba/yukitexture/listener/TextureListener.kt
+++ b/src/main/kotlin/net/azisaba/yukitexture/listener/TextureListener.kt
@@ -67,7 +67,7 @@ class TextureListener(private val plugin: YukiTexture) : Listener {
                         e.player.uniqueId.toString(),
                     )
                 }
-            }, 10) // around 1s
+            }, 20) // around 1s
         }
     }
 }

--- a/src/main/kotlin/net/azisaba/yukitexture/sql/DBConnector.kt
+++ b/src/main/kotlin/net/azisaba/yukitexture/sql/DBConnector.kt
@@ -1,0 +1,68 @@
+package net.azisaba.yukitexture.sql
+
+import org.intellij.lang.annotations.Language
+import java.sql.*
+
+class DBConnector(host: String, database: String, private val user: String, private val password: String) {
+    private val url: String = "jdbc:mysql://$host/$database"
+    private var conn: Connection? = null
+
+    fun connect() {
+        conn = DriverManager.getConnection(this.url, this.user, this.password)
+    }
+
+    private fun checkConnection(): Connection {
+        return conn ?: throw Error("Connection hasn't made yet.")
+    }
+
+    fun findAll(@Language("SQL") sql: String, vararg values: Any): List<HashMap<String, Any?>> {
+        val conn = checkConnection()
+        return conn.createStatement(sql, *values).apply { closeOnCompletion() }.executeQuery().toArray()
+    }
+
+    fun findOne(@Language("SQL") sql: String, vararg values: Any): HashMap<String, Any?>? {
+        var query = sql
+        if (!query.contains(" LIMIT 1")) query += " LIMIT 1"
+        return findAll(query, *values).let { if (it.isEmpty()) null else it[0] }
+    }
+
+    fun execute(@Language("SQL") sql: String, vararg values: Any): Int {
+        val conn = checkConnection()
+        val stmt = conn.createStatement(sql, *values)
+        val i = stmt.executeUpdate()
+        stmt.close()
+        return i
+    }
+
+    companion object {
+        init {
+            Class.forName("org.mariadb.jdbc.Driver")
+        }
+    }
+
+    // Extension functions
+
+    private fun Connection.createStatement(sql: String, vararg values: Any): PreparedStatement {
+        return if (values.isEmpty()) {
+            this.prepareStatement(sql)
+        } else {
+            val preparedStatement = this.prepareStatement(sql)
+            values.forEachIndexed { index, obj -> preparedStatement.setObject(index + 1, obj) }
+            preparedStatement
+        }
+    }
+
+    private fun ResultSet.toArray(): List<HashMap<String, Any?>> {
+        val list = ArrayList<HashMap<String, Any?>>()
+        val columns = this.metaData.columnCount
+        while (this.next()) {
+            val row = HashMap<String, Any?>()
+            for (i in 1..columns) {
+                row[this.metaData.getColumnName(i)] = this.getObject(i)
+            }
+            list.add(row)
+        }
+        this.close()
+        return list
+    }
+}

--- a/src/main/resources/texture.yml
+++ b/src/main/resources/texture.yml
@@ -1,1 +1,23 @@
+# データベースの設定はreloadtex不可
+database:
+  host: localhost
+  name: yukitexture
+  user: yukitexture
+  password:
+  # [life1, life2], [pvp1, pvp2] のように複数のグループに分けてプラグインを使いたい場合のみ変更してください
+  # 最後のアンダーバーがなくても動きますがテーブル名が汚くなります
+  prefix: server_
+
+# リソパのURL (reloadtex可)
 url: ''
+
+# server1 <-> server2の移動の場合はリソースパックが送信されない (reloadtex可)
+dontApplyTexture:
+- server1
+- server2
+
+# サーバー名 (reloadtex不可)
+server: server1
+
+# (reloadtex可)
+delay: 5


### PR DESCRIPTION
<details>
<summary>
変更点とか仕様とか
</summary>

- /reloadtexで保存されたsha1ハッシュをリセット(リソパ更新を強制する)
- Kotlinのバージョンを`1.4.10`→`1.5.10`に更新
- sha1ハッシュがすでに計算されてる場合はダウンロードしないでクライアントにURLとsha1ハッシュをそのまま投げる
- sha1ハッシュの表示を完了メッセージのtooltipに変更
- ~~masterブランチからPRしてるのはミスです、ごめんなさい~~
- 設定項目の追加 (texture.yml)
- texture.ymlにurlだけが存在する(設定を変えていない)場合は今までの仕様のまま
- MySQLかMariaDBが使用可能 (https://github.com/AzisabaNetwork/YukiTexture/pull/5/commits/b6d3330fd4d7c79277f274503e019bc61054c5cf)
</details>

[texture.yml](https://github.com/acrylic-style/YukiTexture/blob/b6d3330fd4d7c79277f274503e019bc61054c5cf/src/main/resources/texture.yml)の詳細
- `database.{host, name, user, password}` - MySQLかMariaDB互換のサーバーの情報を入れるだけ
- `database.prefix` - `life, lifebuild`, `coretol, coretollobby` のように複数のグループに分けてプラグインを使いたいときにテーブル名のprefixを変える用 (末端にアンダーバーをつけないとテーブル名がぐちゃぐちゃになる)
- `url` - 変更なし(リソパのURL)
- `dontApplyTexture` - 特定のサーバー間での移動でリソパを適用しない設定(サーバー名は下記の`server`)
- `server` - サーバー名 (`life`, `lifepve`, `lifebuild`等、上記の`dontApplyTexture`とデータベース内のサーバー名保存で使用)
- `delay` - 特定のサーバー内の移動なのにリソパが再適用される場合のみ変更(19以下がおすすめ、20以上はバグる可能性あり)

プレイヤーから見える変更点
![image](https://user-images.githubusercontent.com/19150229/120880550-6023e280-c606-11eb-9d25-ee6dcb2a96fd.png)

- `レスポンスは...`が初回の人以外は消える
- `SHA-1 を計算しました`が消える
- (設定している場合は)特定のサーバー間の移動ならリソパが再適用されない